### PR TITLE
Fix persistent blog page indicator

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -11,7 +11,7 @@ const siteData = {
     },
     {
       name: 'Blog',
-      link: '/'
+      link: '/blog'
     },
     {
       name: 'About',


### PR DESCRIPTION
Blog indicator was always selected, no-matter which page was being viewed.