### PR TITLE
Exclude pages from blog index

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -5,8 +5,11 @@ class BlogIndex extends React.Component {
   render() {
     const posts = this.props.data.allOrga.edges
     const _posts = posts.map ( ({ node }) => {
-      const title = node.meta.title || node.fields.slug
+      const path = node.fields.slug
+      const title = node.meta.title || path
       const date = node.meta.date
+      const include = '/blog/'
+      if (!path || !path.startsWith(include)) return
       return (
         <div>
           <h3 style={{ marginBottom: '0.2em' }}>


### PR DESCRIPTION
Pages are excluded if they are not placed into the blog folder