### PR TITLE
Change highlighting behaviour 

### DIFF
--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -40,6 +40,14 @@ img {
   border: 5px solid #ffffff;
 }
 
+img::selection {
+  background: rgba(242, 112, 82, 0.75) !important;
+}
+
+img::-moz-selection {
+  background: rgba(242, 112, 82, 0.75) !important;
+}
+
 ::selection {
   background: rgba(242, 112, 82, 0.99) !important;
 }

--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -40,6 +40,14 @@ img {
   border: 5px solid #ffffff;
 }
 
+a::selection {
+  color: #FFFFFF;
+}
+
+a::-moz-selection {
+  color: #FFFFFF;
+}
+
 img::selection {
   background: rgba(242, 112, 82, 0.75) !important;
 }

--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -41,11 +41,11 @@ img {
 }
 
 ::selection {
-  background: rgba(242, 112, 82, 0.99);
+  background: rgba(242, 112, 82, 0.99) !important;
 }
 
 ::-moz-selection {
-  background: rgba(242, 112, 82, 0.99);
+  background: rgba(242, 112, 82, 0.99) !important;
 }
 
 pre {


### PR DESCRIPTION
Now code blocks will be highlighted in orange.  Additionally, links' text colour will change to white when selected, preventing it from blending in with the selection colour.  Also decreases the highlight opacity when images are selected.