### PR TITLE
Set mobile Chrome menu colour to orange

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -23,6 +23,7 @@ const TemplateWrapper = ({ children }) => (
       title={name}
       meta={[
         { name: 'keywords', content: 'gatsbyjs, org-mode, jaxson' },
+        { name: 'theme-color', content: '#463d4e' },
       ]}
     />
     <Header name={name} link={home}/>


### PR DESCRIPTION
Set mobile Chrome menu colour to orange to match the header.