### PR TITLE
Correct blog preview order (Resolve #78)

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -41,8 +41,8 @@ class BlogIndex extends React.Component {
           {date ? <span style={{ fontWeight: 'bold' }}>{date}</span> : null }
           { preview.length ?
             <div>
-              <Link style={{ color: colours.text }} to={node.fields.slug}>Continue reading . . . </Link>
               <div style={{ marginTop: margins.small }} dangerouslySetInnerHTML={{ __html: preview.html() }} />
+              <Link style={{ color: colours.text }} to={node.fields.slug}>Continue reading . . . </Link>
             </div>: null}
         </div>
       )


### PR DESCRIPTION
This corrects the blog index page to display the post preview prior to the continue reading button.