### PR TITLE
Use trailing slash on landing re-direct 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,7 +9,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
     fromPath: `/`,
     isPermanent: true,
     redirectInBrowser: true,
-    toPath: `/projects`,
+    toPath: `/projects/`,
   })
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Uses a trailing slash on the splash page re-direct.  Resolves #100