### PR TITLE
Refactor breadcrumbs to not rely on a package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "gatsby-transformer-orga": "^0.5.1",
     "mime": "^2.2.0",
     "prism-themes": "^1.0.1",
-    "react-breadcrumbs": "^2.1.6",
     "react-document-title": "^2.0.3",
     "react-emotion": "^9.2.9",
     "react-fontawesome": "^1.6.1",

--- a/src/components/breadcrumb.js
+++ b/src/components/breadcrumb.js
@@ -1,26 +1,40 @@
 import React from 'react'
+import Link from 'gatsby-link'
 import FA from 'react-fontawesome'
 import { css } from 'emotion'
 import { colours } from './globals'
-import { Breadcrumbs, Breadcrumb as BreadcrumbElement } from 'react-breadcrumbs';
 import 'font-awesome/css/font-awesome.min.css';
 
-const crumb = css(`
-  span:last-of-type {
-    a {
-      color: ${colours.text};
-      text-decoration: none;
-    }
-  }
+const active = css(`
+  font-weight: bold;
 `)
 
+const font = css(`
+  color: ${colours.text};
+`)
+
+export const Separator = p => (
+  <FA style={{ margin: '0 7px 5px' }} name={p.icon ? p.icon : 'chevron-right'} />
+)
+
 export const Breadcrumb = p => {
+  const depth = p.links.length
   return (
-    <Breadcrumbs className={crumb} separator={<FA style={{ margin: '0 7px 5px' }} name="chevron-right" />}>
+    <nav className={font}>
       {p.links
-        ? p.links.map(({ name, link }) => (
-          <BreadcrumbElement key={link} data={{ title: name, pathname: link }} />))
-          : null}
-    </Breadcrumbs>
+        ? p.links.map(({ name, link }, i) => {
+          if (depth <= i + 1) {
+            return (
+              <span className={active} key={i} aria-current='true'>{name}</span>
+            )
+          }
+          return (
+            <span key={i}>
+              <Link to={link}>{name}</Link>
+              <Separator icon={p.separator}/>
+            </span>
+          )
+        }) : null}
+    </nav>
   )
 }

--- a/src/templates/game.js
+++ b/src/templates/game.js
@@ -65,7 +65,7 @@ class GameTemplate extends Component {
     const tab = makeTitle(title, this.props.data.site.siteMetadata.title)
     const _page = this.page(post)
     const links = [{ name: 'Projects', link: '/projects/'},
-                   { name: `${title}`, link: slug }]
+                   { name: `${title}` }]
     return (
       <DocumentTitle title={tab}>
         <article>

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -29,7 +29,7 @@ class BlogPostTemplate extends Component {
     let links
     if (slug && slug.startsWith(include)) {
       links = [{ name: 'Blog', link: '/blog/'},
-              { name: `${title}`, link: slug }]
+               { name: `${title}` }]
     }
     return (
       <DocumentTitle title={tab}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5046,10 +5046,6 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-
 lodash.isnumber@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
@@ -6859,14 +6855,6 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-breadcrumbs@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/react-breadcrumbs/-/react-breadcrumbs-2.1.6.tgz#e54e718e2ac46e726b6589a19eee30d024fcf5be"
-  dependencies:
-    lodash.isequal "^4.5.0"
-    redux "^3.6.0"
-    uuid "^3.0.1"
 
 react-deep-force-update@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Refactor breadcrumbs to not rely on react-breadcrumbs which in turn requires lodash. 