### PR TITLE
Fix high-res favicon for Android

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -119,7 +119,7 @@ const TemplateWrapper = ({ children }) => (
         { name: 'keywords', content: 'gatsbyjs, org-mode, jaxson' },
         { name: 'theme-color', content: colours.header },
       ]}>
-      <link rel="icon" sizes="192x192" href="favicon-192.png"/>
+      <link rel="icon" sizes="192x192" href="/favicon-192.png"/>
     </Helmet>
     <Header name={name} link={home}/>
     <div className={style}>


### PR DESCRIPTION
Uses a absolute path to the root
of the site rather than a relative path