### PR TITLE
Use tab role for header navigation bar

### DIFF
--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -37,6 +37,7 @@ export const Nav = p => {
               to={link}
               key={link}
               activeStyle={{ borderColor: 'initial' }}
+              role='tab'
             >
               {name}
             </Link>


### PR DESCRIPTION
This will help screen-readers identify the type of content.