### PR TITLE
Add Bitbucket anchors post

### DIFF
--- a/content/blog/anchors-in-bitbucket.org
+++ b/content/blog/anchors-in-bitbucket.org
@@ -1,0 +1,105 @@
+#+TITLE: Using Anchors in Bitbucket Markdown Documents
+#+DATE: October 23, 2018
+
+Using [[https://daringfireball.net/projects/markdown/syntax][Markdown]] to write content is a joy; gone are the days of clunky and [[https://support.microsoft.com/en-ca/help/918793/how-to-optimize-word-2007-and-word-2010][slow word processors]].  Leveraging /HTML/ tags for complete control over your document when needed and falling back to a simple and constant syntax for simpler operations works great.  Most [[https://en.wikipedia.org/wiki/Version_control][VCS]] hosting platforms will recognize the extension and render it. For larger documents typically organizing sections using a table of contents with anchors is an easy and streamlined process.
+
+** Leveraging HTML Anchors
+
+In most documents I find myself doing something like this:
+
+#+BEGIN_SRC markdown
+# Table of Contents
+
+- [Battle Snake 2019](#orgf9ab559)
+    -   [Strategy](#org889b147)
+        -   [Drawbacks](#orgfb85c54)
+    -   [Battle History](#orgcfa9a90)
+    -   [Screenshots](#orgc2991ca)
+    -   [Usage](#org7bfc615)
+        -   [Prerequisites](#orge6d4f36)
+        -   [Test Server](#orgf8ef52a)
+        -   [Run Locally](#org73d091b)
+        -   [Deployment](#org3a27619)
+    -   [Acknowledgments](#org4a0f7fb)
+#+END_SRC
+
+And then later on linking the header to an /HTML/ anchor:
+
+#+BEGIN_SRC markdown
+<a id="org889b147"></a>
+
+## Strategy
+#+END_SRC
+
+Then any other place you want to refer to a section can be done using that ID:
+
+#+BEGIN_SRC markdown
+Another drawback of our [strategy](#org889b147) was ...
+#+END_SRC
+
+This renders great in [[https://github.com/woofers/battle-snake-2018/blob/master/README.md#table-of-contents][Github]] and is done automatically when using [[https://orgmode.org/][Org mode]]'s Markdown exporter.
+
+** This Should Work in Bitbucket Cloud Right?
+#+BEGIN_EXPORT html
+<h4 style='padding-left: 35px'><i class="fa fa-exclamation-triangle"></i> You would be wrong</h4>
+#+END_EXPORT
+
+Bitbucket Cloud very closely follows [[https://daringfireball.net/projects/markdown/syntax][John Gruber]]'s original Markdown specification with the exception of /HTML/ tags.  Attempting to use /HTML/ anchors will simply display the escaped /HTML/ along with broken links.
+
+*** Why?
+
+Straight from [[https://confluence.atlassian.com/bitbucket/readme-content-221449772.html#READMEcontent-ExtensionsandLanguages][Atlassian]]:
+
+#+BEGIN_QUOTE
+We don't support arbitrary HTML in Markdown, for example <table> tags.
+#+END_QUOTE
+
+Bitbucket Cloud uses [[https://github.com/Python-Markdown/markdown][Python Markdown]] to render its Markdown files with the [[https://github.com/Python-Markdown/markdown/blob/b62ddeda02fadcd09def9354eb2ef46a7562a106/docs/reference.md#the-details][Safe Mode]] option *escape* enabled.  This option simply escapes all /HTML/ tags to =plain text=.
+
+This is inconvenient as it greatly limits the customizability of Bitbucket Markdown documents however it prevents Bitbucket from needing to worry about malicious /HTML/ and /scripts/ being injected.
+
+I have seen [[https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html#Markdownsyntaxguide-readmeREADMEfiles][claims]] that /HTML/ tags on the self-hosted Bitbucket Server are enabled however I am not able to confirm this.
+
+** How Does Github Handle It Then?
+Github uses [[https://github.com/gjtorikian/commonmarker][CommonMarker]] which is a Ruby wrapper of [[https://github.com/commonmark/cmark][cmark]], a C implementation of the [[https://commonmark.org/][CommonMark]] spec which whitelists [[https://spec.commonmark.org/0.21/#raw-html][some HTML tags]].
+
+You won't be able to [[https://stackoverflow.com/a/14945782][embed Youtube videos]] however the spec for Github's markup rendering is [[https://github.com/github/markup][documented]] to a much greater extent than that of Bitbucket.
+
+** Exploiting HTML IDs
+
+While there is no solution to allow the use of raw /HTML/ in Bitbucket documents, anchors to headers and table of contents can still be displayed in Bitbucket Cloud.
+
+*** Anchors
+
+This can be done by utilizing the fact that all Markdown headers when rendered in Bitbucket will contain an /HTML ID/ in the form:
+
+~markdown-header-[kebab-case-header]~
+
+For example anchoring to this section in Bitbucket would be done with:
+
+~markdown-header-anchors~
+
+All *spaces* will be replaced with *hyphens* and all *special characters* (/including dots/) will be *removed*.  The ID will also be all *lower-case*.
+
+Linking to the *strategy* section from our previous example would look like:
+
+#+BEGIN_SRC markdown
+Another drawback of our [strategy](#markdown-header-strategy) was ...
+#+END_SRC
+
+This is not ideal as it won't work in other Markdown renderers however it does allow the use of anchors for those who plan to display content exclusively in Bitbucket.  An /HTML/ anchor tag can't be enterted for compatibility since Bitbucket will render it as plain-text.
+
+*** Table of Contents
+
+While the above technique of using anchors could be employed to manually generate a table of contents, a better solution does exist.  By simply inserting the TOC directive as follows, a table of contents should be generated in-place:
+
+#+BEGIN_SRC markdown
+[TOC]
+#+END_SRC
+
+*** Why Does This Work?
+The short answer is that the [[https://confluence.atlassian.com/bitbucket/add-a-table-of-contents-to-a-wiki-221451163.html][Bitbucket Wiki]] documents this directive.  The more in-depth answer is that the Python Markdown extension [[https://github.com/Python-Markdown/markdown/blob/master/docs/extensions/toc.md][TOC]] is being used.  This means that this solution will only work for any renderers powered by Python Markdown.
+
+** Too Much Trouble for Anchors?
+
+For those who were hoping Markdown would be the one true universal format, *its not there* /yet/.  For now to avoid all of this craziness I would recommend simply using Github.  However if you are really stuck with the Bitbucket ecosystem, /as I am at work/, the following should do the trick.

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -21,14 +21,6 @@ injectGlobal(`
     background-color: ${colours.background};
   }
 
-  a::selection {
-    color: ${selections.link};
-  }
-
-  a::-moz-selection {
-    color: ${selections.link};
-  }
-
   img::selection {
     background: ${selections.image} !important;
   }
@@ -39,10 +31,12 @@ injectGlobal(`
 
   ::selection {
     background: ${selections.main} !important;
+    color: ${selections.link};
   }
 
   ::-moz-selection {
     background: ${selections.main} !important;
+    color: ${selections.link};
   }
 
 

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -39,7 +39,6 @@ injectGlobal(`
     color: ${selections.link};
   }
 
-
   code[class*="language-"],
   pre[class*="language-"] {
     background: ${colours.codeBackground} !important;
@@ -63,7 +62,6 @@ const style = css(`
 
   h2 {
     font-size: ${fonts.large}em;
-    margin: 0;
   }
 
   a {

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -18,7 +18,7 @@ class BlogIndex extends React.Component {
     const safeCompare = (a, b, func) =>
       (a || b) ? (!a ? 1 : !b ? -1 : func(a, b) ? 1 : -1) : 0;
     posts.sort(function(a, b) {
-      return safeCompare(date(a.node), date(b.node), (a, b) => new Date(a) < new Date(a));
+      return safeCompare(date(a.node), date(b.node), (a, b) => new Date(a) < new Date(b));
     });
     return posts
   }


### PR DESCRIPTION
Adds a blog post about anchors in Bitbucket Markdown along with some small display tweaks to make blog posts look better.