### PR TITLE
Remove initial blog post

### DIFF
--- a/content/blog/post.org
+++ b/content/blog/post.org
@@ -1,6 +1,0 @@
-#+TITLE: A Post
-#+DATE: September 22, 2018
-
-This will be a *blog post* /(at some point)/.
-
-For now this is a ~placeholder~.


### PR DESCRIPTION
Removes the initial blog post as it was simply a placeholder.  Resolves #141