### PR TITLE
Remove text decoration on links

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -68,7 +68,6 @@ const style = css(`
 
   a {
     color: ${colours.link};
-    text-decoration: none;
     border-bottom: ${margins.line} solid transparent;
     transition: ${transitions.hover}
   }
@@ -76,6 +75,10 @@ const style = css(`
   a:hover {
     padding-bottom: ${animations.link};
     border-color: currentColor;
+  }
+
+  a:focus, a:hover, a:visited, a:link, a:active {
+    text-decoration: none;
   }
 
   blockquote {


### PR DESCRIPTION
Resolves an issue where text decoration was being displayed, in-addition to the link transition.
Resolves #130