### PR TITLE
Refactor templates into more sub-components

### DIFF
--- a/content/about.org
+++ b/content/about.org
@@ -1,5 +1,5 @@
 #+TITLE: About
-#+SHOW_TITLE: nil
+#+TYPE: page
 
 I'm *Jaxson Van Doorn*, a software developer living in *Victoria, BC*.
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,6 +16,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
     const templatesFolder = 'src/templates'
     const templates = {
       blog: path.resolve(`${templatesFolder}/post.js`),
+      page: path.resolve(`${templatesFolder}/page.js`),
       game: path.resolve(`${templatesFolder}/game.js`)
     }
     graphql(

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,8 +13,11 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
   })
 
   return new Promise((resolve, reject) => {
-    const blogPostTemplate = path.resolve(`src/templates/post.js`)
-    const gameTemplate = path.resolve(`src/templates/game.js`)
+    const templatesFolder = 'src/templates'
+    const templates = {
+      blog: path.resolve(`${templatesFolder}/post.js`),
+      game: path.resolve(`${templatesFolder}/game.js`)
+    }
     graphql(
       `
         {
@@ -42,7 +45,8 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         const node = edge.node
         let path = node.meta.slug
         const template = (type) => {
-          return slash(type === 'game' ? gameTemplate : blogPostTemplate)
+          if (!type) type = 'blog'
+          return slash(templates[type])
         }
         if (!path) path = node.fields.slug
         createPage({

--- a/src/components/blog-title.js
+++ b/src/components/blog-title.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export const BlogTitle = p => (
+  <div style={{ textAlign: 'right' }}>
+    {p.title ?
+      <div>
+        <h1 style={{ display: 'inline' }}>{p.title}</h1>
+        {p.icon ?
+         <img style={{ marginLeft: '10px', imageRendering: p.icon.mode }}
+              width="55px" height="55px" src={p.icon.image} /> :
+       null}
+      </div>
+    : null}
+    {p.date ? <p>{p.date}</p> : null }
+  </div>
+)

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { margins } from '../components/globals'
+import { css } from 'emotion'
+
+const hide = css(`
+  div:first-child h1 {
+    display: none;
+  }
+`)
+
+const org = css(`
+  div {
+    margin-bottom: ${margins.small};
+    text-align: 'left';
+  }
+`)
+
+export const Content = p => (
+  <div className={p.hideTitle ? `${org} ${hide}` : org}
+       dangerouslySetInnerHTML={{ __html: p.html }} />
+)

--- a/src/components/frame.js
+++ b/src/components/frame.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { css } from 'emotion'
+import { margins } from '../components/globals'
+
+const noHighlight = css(`
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+`)
+
+const container = css(`
+  text-align: center;
+  margin: ${margins.small} 0;
+  position: relative;
+  padding-top: 56.25%;
+`)
+
+const iframe = css(`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`)
+
+export const Frame = p => (
+  <div className={`${container} ${noHighlight}`}>
+    <iframe src={p.src} className={iframe} frameBorder="0" allowFullScreen />
+  </div>
+)

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { margins } from '../components/globals'
+import { css } from 'emotion'
+import { Content } from '../components/content'
+import { Frame } from '../components/frame'
+
+const grid = css(`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(405px, 1fr));
+  grid-template-rows: 860px;
+  grid-column-gap: 50px;
+  grid-row-gap: 6px;
+`)
+
+export const Game = p => (
+  <div className={p.portrait ? grid : null}>
+    <Frame src={p.src} />
+    <Content html={p.instruction} />
+  </div>
+)

--- a/src/components/page.js
+++ b/src/components/page.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Title } from '../components/title'
+import { Button } from '../components/button'
+import 'font-awesome/css/font-awesome.min.css';
+import FA from 'react-fontawesome'
+
+export const Page = p => (
+  <Title title={p.post.meta.title} site={p.site}>
+    <article>
+      {p.children}
+    </article>
+  </Title>
+)

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -4,6 +4,7 @@ import { css } from 'emotion'
 import cheerio from 'cheerio'
 import { colours, fonts, margins } from '../components/globals'
 import { Title } from '../components/title'
+import { Content } from '../components/content'
 
 const org = css(`
   div {
@@ -41,7 +42,7 @@ class BlogIndex extends React.Component {
           {date ? <span style={{ fontWeight: 'bold' }}>{date}</span> : null }
           { preview.length ?
             <div>
-              <div style={{ marginTop: margins.small }} dangerouslySetInnerHTML={{ __html: preview.html() }} />
+              <Content html={preview.html()} />
               <Link style={{ color: colours.text }} to={node.fields.slug}>Continue reading . . . </Link>
             </div>: null}
         </div>

--- a/src/templates/game.js
+++ b/src/templates/game.js
@@ -1,96 +1,27 @@
 import React, { Component } from "react"
 import { css } from 'emotion'
-import { Title } from '../components/title'
-import { margins } from '../components/globals'
+import { BlogTitle } from '../components/blog-title'
 import { Breadcrumb } from '../components/breadcrumb'
-import { Button } from '../components/button'
-import 'font-awesome/css/font-awesome.min.css';
-import FA from 'react-fontawesome'
-
-const org = css(`
-  div {
-    margin-bottom: ${margins.small};
-  }
-`)
-
-const titleStyle = css(`
-  div:first-child h1 {
-    display: none;
-  }
-`)
-
-const grid = css(`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(405px, 1fr));
-  grid-template-rows: 860px;
-  grid-column-gap: 50px;
-  grid-row-gap: 6px;
-`)
-
-const noHighlight = css(`
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-`)
-
-const iframeContainer = css(`
-  text-align: center;
-  margin: ${margins.small} 0;
-  position: relative;
-  padding-top: 56.25%;
-`)
-
-const iframe = css(`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`)
+import { Game } from '../components/game'
+import { Page } from '../components/page'
 
 class GameTemplate extends Component {
-  page(post) {
-    const divStyle = post.meta.landscape === 'nil' ? grid : ''
-    return (
-      <div className={divStyle}>
-        <div className={`${iframeContainer} ${noHighlight}`}>
-          <iframe src={post.meta.game} className={iframe} frameBorder="0" allowFullScreen />
-        </div>
-        <div style={{ textAlign: 'left' }} dangerouslySetInnerHTML={{ __html: post.html }} />
-      </div>
-    )
-  }
-
   render() {
     const post = this.props.data.orga
-    const slug = post.fields.slug
-    const { title, icon, date } = post.meta
-    const iconMode = post.meta.icon_mode
+    const { title, date, icon, iconMode } = post.meta
     const showTitle = post.meta.show_title !== 'nil'
-    const style = ((title && showTitle) || date) ? org : `${org} ${titleStyle}`
-    const site = this.props.data.site.siteMetadata.title
-    const _page = this.page(post)
     const links = [{ name: 'Projects', link: '/projects/'},
                    { name: `${title}` }]
     return (
-      <Title title={title} site={site}>
-        <article>
-          <Breadcrumb links={links} />
-          <div style={{ textAlign: 'right' }}>
-            {showTitle ?
-              <div>
-                <h1 style={{ display: 'inline' }} >{title}</h1>
-                <img style={{ marginLeft: '10px', imageRendering: iconMode }} width="55px" height="55px" src={icon} />
-              </div>
-              : null }
-            {date ? <p>{date}</p> : null }
-          </div>
-          {_page}
-        </article>
-      </Title>
+      <Page post={post}
+            site={this.props.data.site.siteMetadata.title}>
+        <Breadcrumb links={links} />
+        <BlogTitle title={title} date={date}
+                   icon={{ image: icon, mode: iconMode }} />
+        <Game src={post.meta.game}
+                portrait={post.meta.landscape === 'nil'}
+                instruction={post.html} />
+      </Page>
     )
   }
 }

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -1,0 +1,23 @@
+import React, { Component } from "react"
+import { BlogTitle } from '../components/blog-title'
+import { Content } from '../components/content'
+import { Page } from '../components/page'
+
+class PageTemplate extends Component {
+  render() {
+    const post = this.props.data.orga
+    return (
+      <Page post={post} site={this.props.data.site.siteMetadata.title}>
+        <Content html={post.html} hideTitle={true} />
+      </Page>
+    )
+  }
+}
+
+export default PageTemplate
+
+export const pageQuery = graphql`
+  query Page($slug: String!) {
+    ...Post
+  }
+`

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,52 +1,26 @@
 import React, { Component } from "react"
-import { css } from 'emotion'
-import { Title } from '../components/title'
-import { Button } from '../components/button'
-import { margins } from '../components/globals'
 import { Breadcrumb } from '../components/breadcrumb'
+import { BlogTitle } from '../components/blog-title'
+import { Content } from '../components/content'
+import { Page } from '../components/page'
 
-const org = css(`
-  div {
-    margin-bottom: ${margins.small};
-  }
-`)
-
-const titleStyle = css(`
-  div:first-child h1 {
-    display: none;
-  }
-`)
-
-class BlogPostTemplate extends Component {
+class PostTemplate extends Component {
   render() {
     const post = this.props.data.orga
     const { title, date } = post.meta
-    const slug = post.fields.slug
-    const showTitle = post.meta.show_title !== 'nil'
-    const style = ((title && showTitle) || date) ? org : `${org} ${titleStyle}`
-    const site = this.props.data.site.siteMetadata.title
-    const include = '/blog/'
-    let links
-    if (slug && slug.startsWith(include)) {
-      links = [{ name: 'Blog', link: '/blog/'},
-               { name: `${title}` }]
-    }
+    const links = [{ name: 'Blog', link: '/blog/'},
+                   { name: `${title}` }]
     return (
-      <Title title={title} site={site}>
-        <article>
-          {links ? <Breadcrumb links={links} /> : null}
-          <div style={{ textAlign: 'right' }}>
-            {showTitle ? <h1>{title}</h1> : null }
-            {date ? <p>{date}</p> : null }
-          </div>
-          <div className={style} dangerouslySetInnerHTML={{ __html: post.html }} />
-        </article>
-      </Title>
+      <Page post={post} site={this.props.data.site.siteMetadata.title}>
+        <Breadcrumb links={links} />
+        <BlogTitle title={title} date={date} />
+        <Content html={post.html} />
+      </Page>
     )
   }
 }
 
-export default BlogPostTemplate
+export default PostTemplate
 
 export const pageQuery = graphql`
   query Blog($slug: String!) {


### PR DESCRIPTION
Refactors templates using more sub-components. 

 Also adds the `page` template type which is similar to the `post` template however it does not contain any breadcrumbs or heading.

Components added are as follows:

- **Game** - Displays a game with instructions side-by-side
- **Frame** - Dynamically scaling iframe
- **Blog Title** - Page title header with optional date and icon
- **Content** - Renders Org content
- **Page** - Sets the title and configures tags for the main body of the page