### PR TITLE
Prevent code block font size being overwritten

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -43,7 +43,7 @@ injectGlobal(`
   code[class*="language-"],
   pre[class*="language-"] {
     background: ${colours.codeBackground} !important;
-    font-size: ${fonts.code}em;
+    font-size: ${fonts.code}em !important;
   }
 `)
 


### PR DESCRIPTION
Prevent code block font size being overwritten by Prism. Resolve #136