### PR TITLE
Bump to v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jaxson-site",
   "description": "",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Jaxson Van Doorn",
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
Bug Fixes:

- Resolves an issue where the root page would not re-direct, resulting in a Github pages 404.