### PR TITLE
Bump to v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jaxson-site",
   "description": "",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "Jaxson Van Doorn",
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
Bug Fixes:

- Fix tab title not displaying page name (#172)

Changes:

- Add profile picture to about page