### PR TITLE
Only use relative links for jaxson.vandoorn.ca for local development

### DIFF
--- a/src/components/smart-link.js
+++ b/src/components/smart-link.js
@@ -8,15 +8,19 @@ import { OutboundLink } from 'gatsby-plugin-google-analytics'
 // Adapted from: https://www.gatsbyjs.org/docs/gatsby-link/
 const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
   const data = useStaticQuery(graphql`{ ...Url, ...Pages }`)
-  const { siteUrl } = data.site.siteMetadata
-  const paths = data.allSitePage.nodes.map(node => node.path)
-  const urlNoHttps = siteUrl.replace('https://', '')
-  const urlHttp = siteUrl.replace('https://', 'http://')
+  let link = to
 
-  let link = to.replace(siteUrl, '').replace(urlHttp, '').replace(urlNoHttps, '')
+  // Use relative links for jaxson.vandoorn.ca for local development
+  if (process.env.NODE_ENV !== 'production') {
+    const { siteUrl } = data.site.siteMetadata
+    const paths = data.allSitePage.nodes.map(node => node.path)
+    const urlNoHttps = siteUrl.replace('https://', '')
+    const urlHttp = siteUrl.replace('https://', 'http://')
 
-  if (!link) link = '/'
-  if (!paths.includes(link)) link = to
+    let link = to.replace(siteUrl, '').replace(urlHttp, '').replace(urlNoHttps, '')
+    if (!link) link = '/'
+    if (!paths.includes(link)) link = to
+  }
 
   // Tailor the following test to your environment.
   // This example assumes that any internal link (intended for Gatsby)


### PR DESCRIPTION
This resolves a bug for some links which quickly show a 404 page
prior to going to the page.  This issue also resulted in the back
button from these pages not working as the page would not reload.

This is due to Gatsby attempting to catch any relative links
even if they may not be part of the Gatsby site.