### PR TITLE
Prevent excluded Markdown links from being caught

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jaxson-site",
   "description": "Personal blog by Jaxson Van Doorn",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "author": "Jaxson Van Doorn",
   "homepage": "https://jaxson.vandoorn.ca",
   "dependencies": {

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -11,6 +11,7 @@ import CodeBlock from './code-block'
 import { image } from '../styles/center'
 import github from 'hast-util-sanitize/lib/github'
 import merge from 'lodash.merge'
+import Link from './smart-link'
 const schema = merge(github, { attributes: { '*': ['className', 'type'] } })
 
 export const onlyImages = () => {
@@ -56,7 +57,10 @@ export const Markdown = p => {
   }
   const content = () => {
     let md = remark().use(remark2react, {
-      remarkReactComponents: { pre: CodeBlock },
+      remarkReactComponents: {
+        pre: CodeBlock,
+        a: p => <Link to={p.href}>{p.children}</Link>
+      },
       sanitize: schema
     })
     md = md.use(() => links({ alt: p.alt }))


### PR DESCRIPTION
Uses a custom link component to prevent
certain links from being caught in Markdown content