### PR TITLE
Prevent theme switcher from changing spacing

### DIFF
--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/core'
 const img = code => `//github.githubassets.com/images/icons/emoji/unicode/${code}.png`
 const border = css`
   border-radius: 0 !important;
+  margin-bottom: 0;
 `
 
 const Emoji = ({ emoji, size }) =>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -76,8 +76,11 @@ const style = theme => css`
   }
 
   figure, table, img, iframe {
-    margin-bottom: 0;
     border-width: 0;
+  }
+
+  figure, table, iframe {
+    margin-bottom: 0;
   }
 
   img, canvas {


### PR DESCRIPTION
Prevents light theme from adding `margin-bottom: 0` to images.