### PR TITLE
Bump to 5.6.0

### DIFF
--- a/content/about.org
+++ b/content/about.org
@@ -5,8 +5,6 @@ I enjoy doing both /frontend/ & /backend/ web design work as-well as the occasio
 
 Most of my open-source projects these days are with [[https://reactjs.org/][React]] + [[https://developer.mozilla.org/en-US/docs/Web/JavaScript][JavaScript]], [[https://www.java.com][Java]] or [[https://www.lua.org/][Lua]].
 
-Currently studying my *4th* year of /Computer Science/ at [[https://uvic.ca][University of Victoria]].
-
 You can find some of my [[/][projects]] on this site.
 
 More projects can be found on my [[https://github.com/woofers][GitHub]], along with my [[/resume/jaxsonvd-resume.pdf][resume]].

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jaxs.onl",
   "description": "Personal blog by Jaxson Van Doorn",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "author": "Jaxson Van Doorn",
   "homepage": "https://jaxs.onl",
   "dependencies": {

--- a/src/components/emoji.js
+++ b/src/components/emoji.js
@@ -27,7 +27,7 @@ const toUnicodeBytes = value => {
   return bytes
 }
 
-const img = code => `//github.githubassets.com/images/icons/emoji/unicode/${code}.png`
+const img = code => `https://github.githubassets.com/images/icons/emoji/unicode/${code}.png`
 const border = css`
   border-radius: 0 !important;
   margin-bottom: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3751,9 +3751,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001165:
-  version "1.0.30001170"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
-  integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
+  version "1.0.30001254"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001254.tgz"
+  integrity sha512-GxeHOvR0LFMYPmFGA+NiTOt9uwYDxB3h154tW2yBYwfz2EMX3i1IBgr6gmJGfU0K8KQsqPa5XqLD8zVdP5lUzA==
 
 capitalize@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Changes:

- Remove school

Bug Fixes:

- GitHub emoji CDN now only works with https